### PR TITLE
Call iGDB API to perform logical to physical route conversion

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -50,6 +50,7 @@ awk -F '\t' '{print $1}' routes.aws.us-west-1.us-east-1.by_geo.physical > routes
 - Finally, we can export the distribution of geo-coordinates or ISOs for easy lookup later (e.g. in a database).
 ```Shell
 # (optionally, include additional metrics and remove duplicate consecutive hops) --include hop_count distance_km --remove-duplicate-consecutive-hops
+# (optionally, include iGDB route fiber information using earlier files) --include fiber_wkt_paths fiber_types --physical-routes-tsv routes.aws.us-west-1.us-east-1.by_geo.physical
 ./distribution.routes.py --export-routes-distribution --routes_file routes.aws.us-west-1.us-east-1.by_geo > routes.aws.us-west-1.us-east-1.by_geo.distribution
 ./distribution.routes.py --export-routes-distribution --routes_file routes.aws.us-west-1.us-east-1.by_iso > routes.aws.us-west-1.us-east-1.by_iso.distribution
 ```

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -30,6 +30,13 @@ This produces a file that contains one route on each line, for each source IP, a
 ./itdk_geo.py --convert-ip-to-latlon --routes_file routes.aws.us-west-1.us-east-1.by_ip 1> routes.aws.us-west-1.us-east-1.by_geo
 ```
 
+- (Supplemental) We can further improve the accuracy of the traceroute-level dataset by querying iGDB dataset, provided by an external program.
+```Shell
+mv routes.aws.us-west-1.us-east-1.by_geo routes.aws.us-west-1.us-east-1.by_geo.logical
+./igdb_client.py --convert-to-physical-hops --routes_file routes.aws.us-west-1.us-east-1.by_geo.logical -o routes.aws.us-west-1.us-east-1.by_geo.physical
+awk -F '\t' '{print $1}' routes.aws.us-west-1.us-east-1.by_geo.physical > routes.aws.us-west-1.us-east-1.by_geo
+```
+
 - (Optional) We can visualize the routes using the plot script:
 ```Shell
 ./plot.routes.single_region_pair.py --routes_file routes.aws.us-west-1.us-east-1.by_geo

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -27,6 +27,7 @@ This produces a file that contains one route on each line, for each source IP, a
 
 - We next convert each IP address to a (lat, long) geocoordinate using the ITDK `.nodes.geo` database:
 ```Shell
+# (optionally, remove duplicate consecutive hops) --remove-duplicate-consecutive-hops
 ./itdk_geo.py --convert-ip-to-latlon --routes_file routes.aws.us-west-1.us-east-1.by_ip 1> routes.aws.us-west-1.us-east-1.by_geo
 ```
 
@@ -49,8 +50,8 @@ awk -F '\t' '{print $1}' routes.aws.us-west-1.us-east-1.by_geo.physical > routes
 
 - Finally, we can export the distribution of geo-coordinates or ISOs for easy lookup later (e.g. in a database).
 ```Shell
-# (optionally, include additional metrics and remove duplicate consecutive hops) --include hop_count distance_km --remove-duplicate-consecutive-hops
-# (optionally, include iGDB route fiber information using earlier files) --include fiber_wkt_paths fiber_types --physical-routes-tsv routes.aws.us-west-1.us-east-1.by_geo.physical
+# (optionally, include additional metrics) --include hop_count distance_km
+# (optionally, further include iGDB route fiber information using earlier files) --include fiber_wkt_paths fiber_types --physical-routes-tsv routes.aws.us-west-1.us-east-1.by_geo.physical
 ./distribution.routes.py --export-routes-distribution --routes_file routes.aws.us-west-1.us-east-1.by_geo > routes.aws.us-west-1.us-east-1.by_geo.distribution
 ./distribution.routes.py --export-routes-distribution --routes_file routes.aws.us-west-1.us-east-1.by_iso > routes.aws.us-west-1.us-east-1.by_iso.distribution
 ```

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -55,6 +55,11 @@ awk -F '\t' '{print $1}' routes.aws.us-west-1.us-east-1.by_geo.physical > routes
 ./distribution.routes.py --export-routes-distribution --routes_file routes.aws.us-west-1.us-east-1.by_iso > routes.aws.us-west-1.us-east-1.by_iso.distribution
 ```
 
+- To include the detailed fiber information when exporting geo-coordinate, we can run:
+```Shell
+./distribution.routes.py --export-routes-distribution --include hop_count distance_km fiber_wkt_paths fiber_types --physical-routes-tsv routes.aws.us-west-1.us-east-1.by_geo.physical --routes_file routes.aws.us-west-1.us-east-1.by_geo > routes.aws.us-west-1.us-east-1.by_geo.distribution
+```
+
 ### All region pairs (batch execution)
 
 We created a [batch execution script](./run_all.itdk_links.sh) to loop through all the region pairs that we're interested in and run Dijkstra's in parallel across multiple machines.

--- a/analysis/combine_per_region_pair_tsvs.py
+++ b/analysis/combine_per_region_pair_tsvs.py
@@ -30,8 +30,12 @@ def combine_tsv_files_and_add_regions(input_files: list[str], output_file: str) 
 
         combined_df = pd.concat([combined_df, df], ignore_index=True)
 
-    # Reorder columns with the new ones at the beginning
-    new_columns = ['src_cloud', 'src_region', 'dst_cloud', 'dst_region'] + REQUIRED_COLUMNS
+    # Reorder columns with the new ones and required columns at the beginning
+    FILE_NAME_COLUMNS = ['src_cloud', 'src_region', 'dst_cloud', 'dst_region']
+    per_file_columns = combined_df.columns.tolist()
+    for required_column in FILE_NAME_COLUMNS + REQUIRED_COLUMNS:
+        per_file_columns.remove(required_column)
+    new_columns = FILE_NAME_COLUMNS + REQUIRED_COLUMNS + per_file_columns
     combined_df = combined_df[new_columns]
 
     logging.info(f'Writing to {output_file} ...')

--- a/analysis/common.py
+++ b/analysis/common.py
@@ -25,6 +25,8 @@ RouteInISO = list[str]
 class RouteMetric(str, Enum):
     HopCount = 'hop_count'
     DistanceKM = 'distance_km'
+    FiberWktPaths = 'fiber_wkt_paths'
+    FiberTypes = 'fiber_types'
 
     def __str__(self) -> str:
         return self.value

--- a/analysis/common.py
+++ b/analysis/common.py
@@ -10,7 +10,7 @@ import re
 import sys
 import time
 import logging
-from typing import Optional
+from typing import Any, Optional
 from geopy.distance import geodesic
 
 CARBON_API_URL = 'http://yak-03.sysnet.ucsd.edu'
@@ -134,6 +134,21 @@ def write_routes_to_file(routes: list[list], output_file: Optional[str] = None) 
     if output:
         output.close()
         logging.info('Done')
+
+def remove_duplicate_consecutive_hops(route: list[Any]):
+    """Remove duplicate consecutive hops from the route in-place."""
+    prev_hop = None
+    i = 0
+    # Keep at least 2 hops, aka source and destination.
+    while i < len(route):
+        hop = route[i]
+        if hop == prev_hop:
+            del route[i]
+        else:
+            prev_hop = hop
+            i += 1
+    if len(route) == 1:
+        route.append(route[0])
 
 def detect_cloud_regions_from_filename(filename: str) -> Optional[tuple[str, str, str, str]]:
     """Parse the filename and return a 4-item tuple (src_cloud, src_region, dst_cloud, dst_region)."""

--- a/analysis/distribution.routes.py
+++ b/analysis/distribution.routes.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
 import argparse
+import ast
 from collections import Counter
+import csv
 import io
 import logging
 import sys
@@ -10,6 +12,11 @@ from typing import Any, Optional
 import pandas as pd
 
 from common import RouteMetric, calculate_route_metric, get_routes_from_file, init_logging
+
+PHYSICAL_ROUTE_REQUIRED_METRICS = [
+    RouteMetric.FiberWktPaths,
+    RouteMetric.FiberTypes,
+]
 
 def remove_duplicate_consecutive_hops(route: list[Any]):
     prev_hop = None
@@ -25,10 +32,31 @@ def remove_duplicate_consecutive_hops(route: list[Any]):
     if len(route) == 1:
         route.append(route[0])
 
-def export_routes_distribution(routes: list[list], metrics:list[RouteMetric],
-                               output: Optional[io.TextIOWrapper] = None,
-                               header: bool = False):
-    logging.info('Exporting routes distribution ...')
+def load_physical_routes_tsv(physical_routes_file: io.TextIOWrapper) -> dict[str, dict]:
+    physical_route_info = {}
+    FIELDNAMES = ['routers_latlon', 'distance_km', 'fiber_wkt_paths', 'fiber_types']
+    for metric in RouteMetric:
+        physical_route_info[metric] = {}
+    with physical_routes_file as f:
+        csv_reader = csv.DictReader(f, delimiter='\t', fieldnames=FIELDNAMES)
+        for row in csv_reader:
+            routers_latlon = ast.literal_eval(row['routers_latlon'])
+            route_id = '|'.join([str(e) for e in routers_latlon])
+            physical_route_info[RouteMetric.HopCount][route_id] = len(routers_latlon)
+            physical_route_info[RouteMetric.DistanceKM][route_id] = float(row['distance_km'])
+            physical_route_info[RouteMetric.FiberWktPaths][route_id] = row['fiber_wkt_paths']
+            physical_route_info[RouteMetric.FiberTypes][route_id] = row['fiber_types']
+    return physical_route_info
+
+def lookup_physical_route_metric(route: str, metric: RouteMetric, physical_route_info: dict[str, dict]):
+    try:
+        return physical_route_info[metric][route]
+    except KeyError as ex:
+        raise ValueError(f'Route {route} not found in physical route info') from ex
+
+def calculate_routes_distribution(routes: list[list], metrics:list[RouteMetric],
+                                  physical_route_info: Optional[dict[str, dict]] = None) -> pd.DataFrame:
+    logging.info('Calculating routes distribution ...')
 
     columns = ['count'] + [metric for metric in metrics] + ['route']
 
@@ -37,15 +65,24 @@ def export_routes_distribution(routes: list[list], metrics:list[RouteMetric],
     for route_str, count in sorted(Counter(routes_as_str).items(), key=lambda x: x[1], reverse=True):
         row: list[Any] = [count]
         for metric in metrics:
-            value = calculate_route_metric(route_str, metric)
+            if physical_route_info is not None and metric in physical_route_info:
+                value = lookup_physical_route_metric(route_str, metric, physical_route_info)
+            else:
+                value = calculate_route_metric(route_str, metric)
             row.append(value)
         row.append(route_str)
         rows.append(row)
 
     df = pd.DataFrame(rows, columns=columns)
-    df.to_csv(output if output else sys.stdout, sep='\t', index=False, header=header)
 
     logging.info('Done')
+
+    return df
+
+def export_routes_distribution(routes_distribution: pd.DataFrame,
+                               output: Optional[io.TextIOWrapper] = None,
+                               header: bool = False) -> None:
+    routes_distribution.to_csv(output if output else sys.stdout, sep='\t', index=False, header=header)
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -57,11 +94,20 @@ def parse_args():
     parser.add_argument('--no-header', action='store_true', help='Do not include the header in the output.')
     parser.add_argument('--include', nargs='*', type=RouteMetric, choices=list(RouteMetric),
                         help='The additional metrics to include.')
+    parser.add_argument('--physical-routes-tsv', type=argparse.FileType('r'),
+                        help='The physical routes TSV file, each line contains a list of (lat, long) coordinates and represents a route.')
     parser.add_argument('-o', '--output-tsv', type=argparse.FileType('w'), help='The output TSV file.')
     args = parser.parse_args()
 
     if not args.include:
         args.include = []
+
+    if any([metric in PHYSICAL_ROUTE_REQUIRED_METRICS for metric in args.include]) and not args.physical_routes_tsv:
+        parser.error('Physical routes TSV file is required if physical hop metrics are included.')
+
+    if args.remove_duplicate_consecutive_hops and args.physical_routes_tsv:
+        # TODO: move remove-duplicate-consecutive-hops to the previous step.
+        parser.error('Cannot remove duplicate consecutive hops if physical routes TSV file is provided.')
 
     return args
 
@@ -74,7 +120,9 @@ def main():
         if args.remove_duplicate_consecutive_hops:
             for route in routes:
                 remove_duplicate_consecutive_hops(route)
-        export_routes_distribution(routes, args.include, args.output_tsv, not args.no_header)
+        physical_route_info = load_physical_routes_tsv(args.physical_routes_tsv) if args.physical_routes_tsv else None
+        routes_distribution = calculate_routes_distribution(routes, args.include, physical_route_info)
+        export_routes_distribution(routes_distribution, args.output_tsv, not args.no_header)
     else:
         raise ValueError('No action specified')
 

--- a/analysis/distribution.routes.py
+++ b/analysis/distribution.routes.py
@@ -11,26 +11,12 @@ from typing import Any, Optional
 
 import pandas as pd
 
-from common import RouteMetric, calculate_route_metric, get_routes_from_file, init_logging
+from common import RouteMetric, calculate_route_metric, get_routes_from_file, init_logging, remove_duplicate_consecutive_hops
 
 PHYSICAL_ROUTE_REQUIRED_METRICS = [
     RouteMetric.FiberWktPaths,
     RouteMetric.FiberTypes,
 ]
-
-def remove_duplicate_consecutive_hops(route: list[Any]):
-    prev_hop = None
-    i = 0
-    # Keep at least 2 hops, aka source and destination.
-    while i < len(route):
-        hop = route[i]
-        if hop == prev_hop:
-            del route[i]
-        else:
-            prev_hop = hop
-            i += 1
-    if len(route) == 1:
-        route.append(route[0])
 
 def load_physical_routes_tsv(physical_routes_file: io.TextIOWrapper) -> dict[str, dict]:
     physical_route_info = {}

--- a/analysis/igdb_client.py
+++ b/analysis/igdb_client.py
@@ -128,8 +128,12 @@ def convert_logical_route_to_physical_route(logical_route: LogicalRoute) -> Phys
 def convert_all_logical_routes_to_physical_routes(logical_routes: list[LogicalRoute],
                                                   output: Optional[io.TextIOWrapper]) -> None:
     for logical_route in logical_routes:
-        physical_route = convert_logical_route_to_physical_route(logical_route)
-        print(physical_route.to_tsv(), file=output if output else sys.stdout)
+        try:
+            physical_route = convert_logical_route_to_physical_route(logical_route)
+            print(physical_route.to_tsv(), file=output if output else sys.stdout)
+        except AssertionError as ex:
+            logging.error(f"Ignoring failed conversion of logical route {logical_route}: {ex}")
+            logging.error(traceback.format_exc())
 
 def parse_args():
     parser = argparse.ArgumentParser()

--- a/analysis/igdb_client.py
+++ b/analysis/igdb_client.py
@@ -2,6 +2,7 @@
 
 import argparse
 from dataclasses import dataclass
+import functools
 import io
 import logging
 import math
@@ -116,6 +117,7 @@ def validate_start_end_offset(logical_route: LogicalRoute, physical_route: Physi
     assert start_offset_km < DISTANCE_THRESHOLD_KM, 'Start offset is too large: %f km' % start_offset_km
     assert end_offset_km < DISTANCE_THRESHOLD_KM, 'End offset is too large: %f km' % end_offset_km
 
+@functools.cache
 def convert_logical_route_to_physical_route(logical_route: LogicalRoute) -> PhysicalRoute:
     logging.info('Converting logical route %s ...', logical_route)
     physical_route: PhysicalRoute = PhysicalRoute([], 0, MultiLineString([]), [])
@@ -129,7 +131,7 @@ def convert_all_logical_routes_to_physical_routes(logical_routes: list[LogicalRo
                                                   output: Optional[io.TextIOWrapper]) -> None:
     for logical_route in logical_routes:
         try:
-            physical_route = convert_logical_route_to_physical_route(logical_route)
+            physical_route = convert_logical_route_to_physical_route(tuple(logical_route))
             print(physical_route.to_tsv(), file=output if output else sys.stdout)
         except AssertionError as ex:
             logging.error(f"Ignoring failed conversion of logical route {logical_route}: {ex}")

--- a/analysis/igdb_client.py
+++ b/analysis/igdb_client.py
@@ -65,7 +65,7 @@ class PhysicalRoute:
         ])
 
 session = requests_cache.CachedSession('igdb_cache', backend='filesystem')
-IGDB_API_URL = 'http://localhost:8082'
+IGDB_API_URL = 'http://localhost:8083'
 
 def load_fiber_wkt_paths(fiber_wkt_paths: str) -> MultiLineString:
     try:

--- a/analysis/run_all.conversions.sh
+++ b/analysis/run_all.conversions.sh
@@ -14,6 +14,11 @@ for file in routes.*.by_geo; do
     echo "Processing $file ..."
     name="$(basename "$file" ".by_geo")"
 
+    # Call iGDB to convert logical hops to physical hops
+    mv $name.by_geo $name.by_geo.logical
+    ./igdb_client.py --convert-to-physical-hops --routes_file $name.by_geo.logical -o $name.by_geo.physical
+    awk -F '\t' '{print $1}' $name.by_geo.physical > $name.by_geo
+
     # Geo distribution
     ./distribution.routes.py --export-routes-distribution --include hop_count distance_km --remove-duplicate-consecutive-hops --routes_file "$name.by_geo" > "$name.by_geo.distribution"
 
@@ -29,11 +34,11 @@ for file in routes.*.by_geo; do
     # ISO distribution
     ./distribution.routes.py --export-routes-distribution --routes_file "$name.by_iso" > "$name.by_iso.distribution"
 
-    chmod 440 "$name.by_geo.distribution" $name.by_iso $name.by_iso.distribution
+    chmod 440 "$name.by_geo."{logical,physical} "$name.by_geo.distribution" $name.by_iso $name.by_iso.distribution
 done
 
 mkdir region_pair.by_geo region_pair.by_geo.distribution region_pair.by_iso region_pair.by_iso.distribution
-mv routes.*.by_geo region_pair.by_geo/
+mv routes.*.by_geo{,.logical,.physical} region_pair.by_geo/
 mv routes.*.by_geo.distribution region_pair.by_geo.distribution/
 mv routes.*.by_iso region_pair.by_iso/
 mv routes.*.by_iso.distribution region_pair.by_iso.distribution/

--- a/analysis/run_all.conversions.sh
+++ b/analysis/run_all.conversions.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")"
 set -e
 
 # IP-to-geo conversion
-./itdk_geo.py --convert-ip-to-latlon --filter-geo-coordinate-by-ground-truth --geo-coordinate-ground-truth-csv ./results/geo_distributions/geo_distribution.all.csv --routes_file region_pair.by_ip/routes.*.by_ip --outputs
+./itdk_geo.py --convert-ip-to-latlon --remove-duplicate-consecutive-hops --filter-geo-coordinate-by-ground-truth --geo-coordinate-ground-truth-csv ./results/geo_distributions/geo_distribution.all.csv --routes_file region_pair.by_ip/routes.*.by_ip --outputs
 chmod 440 routes.*.by_geo
 
 for file in routes.*.by_geo; do

--- a/analysis/run_all.conversions.sh
+++ b/analysis/run_all.conversions.sh
@@ -20,7 +20,7 @@ for file in routes.*.by_geo; do
     awk -F '\t' '{print $1}' $name.by_geo.physical > $name.by_geo
 
     # Geo distribution
-    ./distribution.routes.py --export-routes-distribution --include hop_count distance_km --remove-duplicate-consecutive-hops --routes_file "$name.by_geo" > "$name.by_geo.distribution"
+    ./distribution.routes.py --export-routes-distribution --include hop_count distance_km fiber_wkt_paths fiber_types --physical-routes-tsv $name.by_geo.physical --routes_file "$name.by_geo" > "$name.by_geo.distribution"
 
     # Geo-to-ISO conversion
     ./carbon_client.py --convert-latlon-to-carbon-region --routes_file "$file" > "$name".by_iso


### PR DESCRIPTION
This update includes additional information from iGDB API, mainly fiber WKT paths and fiber type for each part of the WKT paths.
We also updated the step-by-step and batch (end-to-end) instructions to reflect the change.